### PR TITLE
ci: skip concurrent jobs

### DIFF
--- a/.github/workflows/maturin.yaml
+++ b/.github/workflows/maturin.yaml
@@ -3,7 +3,7 @@
 #
 #    maturin generate-ci github --zig
 #
-name: Maturin
+name: maturin
 
 on:
   push:
@@ -18,7 +18,22 @@ permissions:
   contents: read
 
 jobs:
+  # Adapted from https://github.com/marketplace/actions/skip-duplicate-actions
+  pre_job:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      # Don't skip jobs when pushing to master
+      should_skip: ${{ steps.skip_check.outputs.should_skip && ! (github.event_name == 'push' && github.ref == 'refs/heads/master') }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # https://github.com/marketplace/actions/skip-duplicate-actions#skip-concurrent-workflow-runs
+          concurrent_skipping: "same_content_newer"
+
   linux:
+    needs: pre_job
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -42,6 +57,7 @@ jobs:
           path: dist
 
   windows:
+    needs: pre_job
     runs-on: windows-latest
     strategy:
       matrix:
@@ -65,6 +81,7 @@ jobs:
           path: dist
 
   macos:
+    needs: pre_job
     runs-on: macos-latest
     strategy:
       matrix:
@@ -87,6 +104,7 @@ jobs:
           path: dist
 
   sdist:
+    needs: pre_job
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
   # Adapted from https://github.com/marketplace/actions/skip-duplicate-actions
   pre_job:
-    # continue-on-error: true # TODO: Uncomment once integration is finished
+    continue-on-error: true
     runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,7 +1,23 @@
-name: Python (tox)
+name: tox
 on: [push]
 jobs:
+  # Adapted from https://github.com/marketplace/actions/skip-duplicate-actions
+  pre_job:
+    # continue-on-error: true # TODO: Uncomment once integration is finished
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      # Don't skip jobs when pushing to master
+      should_skip: ${{ steps.skip_check.outputs.should_skip && ! (github.event_name == 'push' && github.ref == 'refs/heads/master') }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # https://github.com/marketplace/actions/skip-duplicate-actions#skip-concurrent-workflow-runs
+          concurrent_skipping: "same_content_newer"
+
   test:
+    needs: pre_job
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30


### PR DESCRIPTION
## Proposed changes

1. Skip concurrent jobs on duplicated runs.

## Checklist

- [x] Read the [contribution guidelines](https://github.com/andreoliwa/logseq-doctor/blob/master/CONTRIBUTING.rst)
- [x] Add tests for the relevant parts
- [x] Write documentation when there's a new API or functionality
