### PR TITLE
feat(tidy-up): check consecutive spaces in Go

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        # Target coverage for the whole project https://docs.codecov.com/docs/commit-status#target
+        target: 50%
+
+        # Maximum decrease in coverage https://docs.codecov.com/docs/commit-status#threshold
+        threshold: 10%
+
+    patch:
+      default:
+        # No target for code difference on a PR https://docs.codecov.com/docs/commit-status#target
+        target: 0%

--- a/Makefile
+++ b/Makefile
@@ -80,10 +80,6 @@ uninstall: clean .uninstall-global # Remove both local and global (virtualenv an
 	-pyenv uninstall -f $$(basename $$(pwd))
 .PHONY: uninstall
 
-example: develop # Run a simple example of Python code calling Rust code
-	python -c "from logseq_doctor import rust_ext; print(rust_ext.remove_consecutive_spaces('    - abc   123     def  \n'))"
-.PHONY: example
-
 run: develop rehash # Run the CLI with a Python click script as the entry point
 	lsd --help
 .PHONY: run
@@ -123,7 +119,7 @@ release: # Bump the version, create a tag, commit and push. This will trigger th
 	gh repo view --web
 .PHONY: .release-post-bump
 
-smoke: run example test # Run simple tests to make sure the package is working
+smoke: run test # Run simple tests to make sure the package is working
 .PHONY: smoke
 
 clippy: develop # Run clippy on the Rust code

--- a/python/logseq_doctor/cli.py
+++ b/python/logseq_doctor/cli.py
@@ -77,9 +77,9 @@ def _call_golang_exe(command: str, markdown_file: Path) -> int:
             return 1
         return 0
 
+    # TODO: install the Go executable when the Python package is installed
     exe_path = Path(exe_str).expanduser()
     if not exe_path.exists():
-        # TODO: install the Go executable when the Python package is installed
         if display_errors:
             typer.secho(f"The executable '{exe_path}' does not exist.", fg=typer.colors.RED, bold=True)
         return 2

--- a/rust/logseq-doctor/src/lib.rs
+++ b/rust/logseq-doctor/src/lib.rs
@@ -8,15 +8,9 @@ use std::path::PathBuf;
 
 #[pymodule]
 fn rust_ext(_python: Python, module: &Bound<PyModule>) -> PyResult<()> {
-    module.add_function(wrap_pyfunction!(remove_consecutive_spaces, module)?)?;
     module.add_function(wrap_pyfunction!(add_content, module)?)?;
     module.add_function(wrap_pyfunction!(tidy_up, module)?)?;
     Ok(())
-}
-
-#[pyfunction]
-fn remove_consecutive_spaces(file_contents: String) -> PyResult<String> {
-    Ok(logseq::remove_consecutive_spaces(file_contents).unwrap())
 }
 
 #[pyfunction]

--- a/tests/test_cli_tidy_up.py
+++ b/tests/test_cli_tidy_up.py
@@ -13,7 +13,7 @@ def test_remove_empty_bullets_from_multiple_files(datadir: Path) -> None:
 
     result = CliRunner().invoke(app, ["tidy-up", str(actual1), str(actual2)])
     assert result.output == f"{actual1}: empty bullets{os.linesep}{actual2}: empty bullets{os.linesep}"
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert actual1.read_text() == expected1.read_text().strip()
     assert actual2.read_text() == expected2.read_text().strip()
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ env =
     LOGSEQ_HOST_URL=http://localhost:1234
     LOGSEQ_API_TOKEN=token
     LOGSEQ_GRAPH_PATH=~/my-notes
+    LOGSEQ_GO_EXE_PATH=
+    LOGSEQ_GO_IGNORE_ERRORS=1
 norecursedirs =
     migrations
 


### PR DESCRIPTION
## Proposed changes

1. Check consecutive spaces in Go.
2. Removing them will be done in a follow-up PR.
3. First, I need to:
   - add some tests
   - modify `logseq-go` again to open transaction pages via path.
