### PR TITLE
fix: find text inside backticks

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,10 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - funlen
+        path: _test\.go
 formatters:
   exclusions:
     generated: lax

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseDateFromJournalFlag(t *testing.T) { //nolint:funlen
+func TestParseDateFromJournalFlag(t *testing.T) {
 	frozenTime := time.Date(2025, 4, 5, 3, 0, 0, 0, time.UTC)
 	timeNow := func() time.Time {
 		return frozenTime

--- a/cmd/md_test.go
+++ b/cmd/md_test.go
@@ -15,7 +15,7 @@ import (
 // We use dependency injection to make the command testable without executing
 // the actual external dependencies.
 
-func TestMdCommand_WithDependencyInjection(t *testing.T) { //nolint:funlen
+func TestMdCommand_WithDependencyInjection(t *testing.T) {
 	graphPath := "/test/graph"
 	frozenTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 

--- a/cmd/task_test.go
+++ b/cmd/task_test.go
@@ -24,7 +24,7 @@ func TestNewTaskCmd(t *testing.T) {
 	assert.Contains(t, taskCmd.Long, "Manage tasks in your Logseq graph")
 }
 
-func TestTaskAddCommand_WithDependencyInjection(t *testing.T) { //nolint:funlen,maintidx
+func TestTaskAddCommand_WithDependencyInjection(t *testing.T) { //nolint:maintidx
 	graphPath := "/test/graph"
 	frozenTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,6 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
-github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
-github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=

--- a/internal/finder.go
+++ b/internal/finder.go
@@ -54,7 +54,7 @@ func replaceCurrentPage(query, pageTitle string) string {
 }
 
 // containsTextCaseInsensitive checks if a node contains the specified text (case-insensitive).
-// It checks Text, PageLink, Hashtag, and Link nodes (including link URLs and text content).
+// It checks Text, PageLink, Hashtag, CodeSpan, and Link nodes (including link URLs and text content).
 func containsTextCaseInsensitive(node content.Node, searchTextLower string) bool {
 	if text, ok := node.(*content.Text); ok {
 		return strings.Contains(strings.ToLower(text.Value), searchTextLower)
@@ -66,6 +66,10 @@ func containsTextCaseInsensitive(node content.Node, searchTextLower string) bool
 
 	if hashtag, ok := node.(*content.Hashtag); ok {
 		return strings.Contains(strings.ToLower(hashtag.To), searchTextLower)
+	}
+
+	if codeSpan, ok := node.(*content.CodeSpan); ok {
+		return strings.Contains(strings.ToLower(codeSpan.Value), searchTextLower)
 	}
 
 	if link, ok := node.(*content.Link); ok {

--- a/internal/finder_test.go
+++ b/internal/finder_test.go
@@ -81,6 +81,16 @@ func TestFindBlockContainingText(t *testing.T) {
 			searchText:   "tag",
 			expectedText: "First paragraph with a #tag",
 		},
+		{
+			name:         "search for inline code",
+			searchText:   "inline code",
+			expectedText: "Block with `inline code` text",
+		},
+		{
+			name:         "search for text in deep nested inline code",
+			searchText:   "deep code",
+			expectedText: "Deep nested with `deep code` text",
+		},
 	}
 
 	for _, test := range tests {
@@ -197,6 +207,12 @@ func getFindTaskByKeyTestCases() []struct {
 			parentText:   "",
 			expectedText: "WAITING Fourth task with a #tag",
 		},
+		{
+			name:         "search for inline code in task",
+			key:          "code key",
+			parentText:   "",
+			expectedText: "TODO Task with `code key` inside",
+		},
 	}
 }
 
@@ -234,6 +250,10 @@ func extractTextFromNodes(nodes content.NodeList, builder *strings.Builder) {
 		case *content.Hashtag:
 			builder.WriteString("#")
 			builder.WriteString(nodeTyped.To)
+		case *content.CodeSpan:
+			builder.WriteString("`")
+			builder.WriteString(nodeTyped.Value)
+			builder.WriteString("`")
 		case content.HasChildren:
 			extractTextFromNodes(nodeTyped.Children(), builder)
 		}

--- a/internal/md_test.go
+++ b/internal/md_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInsertMarkdownToJournal(t *testing.T) { //nolint:funlen
+func TestInsertMarkdownToJournal(t *testing.T) {
 	tests := []struct {
 		name           string
 		date           time.Time

--- a/internal/nodes_test.go
+++ b/internal/nodes_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsAncestor(t *testing.T) { //nolint:funlen
+func TestIsAncestor(t *testing.T) {
 	tests := []struct {
 		name     string
 		setup    func() (*content.Block, *content.Block)

--- a/internal/tasks_test.go
+++ b/internal/tasks_test.go
@@ -83,7 +83,7 @@ func TestDoing(t *testing.T) {
 	}
 }
 
-func TestAddTaskToPageOrJournal(t *testing.T) { //nolint:funlen
+func TestAddTaskToPageOrJournal(t *testing.T) {
 	frozenTime := time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
@@ -216,7 +216,7 @@ func TestAddTaskUnderBlock(t *testing.T) {
 	}
 }
 
-func TestAddOrUpdateTaskByKey(t *testing.T) { //nolint:funlen
+func TestAddOrUpdateTaskByKey(t *testing.T) {
 	defaultFrozenTime := time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {

--- a/internal/testdata/stub-graph/pages/finder.md
+++ b/internal/testdata/stub-graph/pages/finder.md
@@ -22,3 +22,8 @@
   - Item with a #tag
 - Line after 2
 - Line after 3
+- Block with `inline code` text
+- TODO Task with `code key` inside
+- Parent block with inline code
+  - Nested block with code
+    - Deep nested with `deep code` text


### PR DESCRIPTION
## Proposed changes

1. Find Markdown text inside code spans with backticks.

## Checklist

- [x] Read the [contribution guidelines](https://github.com/andreoliwa/logseq-doctor/blob/master/docs/contributing.md)
- [x] Add tests for the relevant parts
- [x] Write documentation when there's a new API or functionality
